### PR TITLE
Fix creation of Data packs with driver subfolders

### DIFF
--- a/nishizumi_setups_sync.py
+++ b/nishizumi_setups_sync.py
@@ -374,7 +374,6 @@ def sync_data_pack_folders(
     dest_team,
     algorithm="md5",
     copy_all=False,
-    drivers=None,
 ):
     """Synchronise the ``Data packs`` subfolder across all cars."""
     src_dp = os.path.join(src_team, "Data packs")
@@ -392,7 +391,7 @@ def sync_data_pack_folders(
         dest_dp,
         algorithm,
         copy_all,
-        drivers,
+        drivers=None,
     )
 
 
@@ -711,7 +710,6 @@ def run_silent(cfg, ask=False):
             dst_name,
             cfg["hash_algorithm"],
             cfg.get("copy_all", False),
-            drivers,
         )
     sync_nascar_data_packs(ir_folder, dst_name, cfg["hash_algorithm"])
 


### PR DESCRIPTION
## Summary
- avoid creating duplicate driver folders inside the `Data packs` subfolder
- adjust call to `sync_data_pack_folders`

## Testing
- `python -m py_compile nishizumi_setups_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_6841b1153abc832a8eb1130a246758cf