### PR TITLE
Add per-car driver folder choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ not exist.
 * **Number of drivers** – how many driver folders to create when manual entry is
   enabled.
 * **Driver N Name** – text fields for each driver folder name. Use names only.
+* **Select cars for driver folders individually** – when enabled, the tool asks
+  for each car whether driver folders should be created. Cars answered with "No"
+  only receive the `Common Setups` folder.
 * **Use extra sync folders** – when enabled, the additional folders listed below
   are copied as subfolders inside the source folder for every car before the
   usual sync copies the files to the team folder.


### PR DESCRIPTION
## Summary
- allow selecting which cars create driver folders
- remember the car choices
- document new option in README

## Testing
- `python -m py_compile nishizumi_setups_sync.py`
- `python nishizumi_setups_sync.py --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841b3dbcb9c832a8852bd59527b5e16