### PR TITLE
Ensure personal folder uses supplier subfolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ running on a server), the script also falls back to silent mode.
 3. Fill in the team, personal, setup supplier folder and season folder names
    with *folder names only*. These folders must exist inside your iRacing setups
    folder and will be created automatically if they do not. The script uses
-   these folders inside every car directory.
+   these folders inside every car directory. When importing from a ZIP or
+   folder, the personal folder also includes the setup supplier and season
+   subfolders so the structure matches the team folder.
 4. Optionally enable backup or logging and browse to the **Backup Folder** and
    log file locations.
 5. Click **Save Config** to store your settings without running.
@@ -133,7 +135,9 @@ not exist.
 * **Team Folder Name (destination)** – team directory to place files in
   (default `Example Team`). Use only the folder name; do not include a path.
 * **Personal Folder Name (source)** – your personal folder that provides
-  files (default `My Personal Folder`). Name only, no path.
+  files (default `My Personal Folder`). Name only, no path. When importing
+  from a ZIP or folder this folder also contains the setup supplier and
+  season subfolders, mirroring the team folder layout.
 * **Setup Supplier Folder Name (inside team folder)** – subfolder for your
   setup supplier name (default `Example Supplier`). Invalid characters and
   trailing spaces are automatically removed. Name only.

--- a/nishizumi_setups_sync.py
+++ b/nishizumi_setups_sync.py
@@ -600,7 +600,12 @@ def copy_from_source(source, iracing_folder, cfg, ask=False):
         if not setup_name:
             continue
         target = os.path.join(iracing_folder, setup_name)
-        personal = os.path.join(target, cfg["personal_folder"])
+        personal = os.path.join(
+            target,
+            cfg["personal_folder"],
+            cfg["driver_folder"],
+            cfg["season_folder"],
+        )
         team = os.path.join(
             target,
             cfg["team_folder"],


### PR DESCRIPTION
## Summary
- keep supplier and season subfolders inside the personal folder when importing
- document the new personal folder structure

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cabe0aa8832ab76c2e316319664e