### PR TITLE
Improve driver-style sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ This repository provides Python script `nishizumi_setups_sync.py` to copy iRacin
 - Optionally create driver-specific folders in the destination. When enabled,
   setups are synced to a `Common Setups` folder and to each named driver folder
   without overwriting the drivers' custom versions.
+- When driver folders are active, imported setups and any extra sync folders are
+  automatically copied into each driver directory and the `Common Setups`
+  folder.
 - Optional Garage61 integration can fetch the list of drivers from the
   Garage61 API so driver folders are created and removed automatically.
 - When an unknown car folder is detected while running the GUI,


### PR DESCRIPTION
## Summary
- handle imports and syncing when driver folders already exist
- copy extra sync folders into driver directories
- update README to mention driver folder behaviour

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile nishizumi_setups_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_6841d0bdb06c832ab43c1a58ba778584