### PR TITLE
Fix copying extra folders from destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ This repository provides Python script `nishizumi_setups_sync.py` to copy iRacin
     tools) are copied as subfolders inside the source folder before the normal
     synchronisation copies everything to the team folder. Each extra folder can
     be taken either from the car directory or from inside the sync destination
-    folder.
+    folder. When gathered from the destination folder the original is removed
+    after copying to keep things tidy.
 - By default only `.sto` files are copied; a checkbox allows copying every file
   type instead.
 - Optionally create driver-specific folders in the destination. When enabled,

--- a/nishizumi_setups_sync.py
+++ b/nishizumi_setups_sync.py
@@ -493,8 +493,10 @@ def merge_external_into_source(
             loc = ext_def.get("location", "car")
             if loc == "dest":
                 ext = os.path.join(car_dir, dest_name, folder_name)
+                remove_after = True
             else:
                 ext = os.path.join(car_dir, folder_name)
+                remove_after = False
             if not os.path.exists(ext):
                 continue
             if driver_style and drivers is not None:
@@ -530,6 +532,8 @@ def merge_external_into_source(
                     delete_extras=False,
                     copy_all=copy_all,
                 )
+            if remove_after:
+                shutil.rmtree(ext, ignore_errors=True)
 
 
 def sync_data_pack_folders(


### PR DESCRIPTION
## Summary
- remove extra folders from destination after merging into source
- document that destination folders are removed when gathered as extras

## Testing
- `python -m py_compile nishizumi_setups_sync.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6841de02a104832a876a95f85f60c07d