### PR TITLE
Add CONTRIBUTING and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run with '...'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+- OS: [e.g. Windows 11]
+- Python version: `python --version`
+- Program version: latest commit or release used
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing
+
+Thank you for your interest in improving Nishizumi Setups Sync. The following guidelines explain how to report issues and send pull requests.
+
+## Reporting Issues
+
+1. Search the existing [issues](https://github.com/nishizumi-maho/nishizumi-setups-sync/issues) to check if your problem has already been reported.
+2. If not, open a new issue using the appropriate template:
+   - **Bug report** for problems with the current behaviour.
+   - **Feature request** for ideas and enhancements.
+3. Provide as much detail as possible, including steps to reproduce bugs or your use case for new features.
+
+## Pull Requests
+
+1. Fork the repository and create a new branch for your work.
+2. Make your changes and ensure the program still compiles:
+   ```bash
+   python -m py_compile nishizumi_setups_sync.py
+   ```
+3. Commit your work with a clear message and open a pull request targeting the `main` branch.
+4. Reference any related issues in the pull request description.
+
+## Contact
+
+For questions or help, open an issue or mention **@nishizumi-maho** on GitHub.


### PR DESCRIPTION
## Summary
- add templates for bug reports and feature requests
- document how to contribute and contact maintainers

## Testing
- `python -m py_compile nishizumi_setups_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_6841efd0cecc832ab1770f78b557f52d