### PR TITLE
Fix silent mode detection when stdin is missing

### DIFF
--- a/nishizumi_setups_sync.py
+++ b/nishizumi_setups_sync.py
@@ -1091,7 +1091,10 @@ def main():
     if "--silent" in sys.argv or (
         cfg.get("run_on_startup", False)
         and "--gui" not in sys.argv
-        and not sys.stdin.isatty()
+        and (
+            not hasattr(sys.stdin, "isatty")
+            or not sys.stdin.isatty()
+        )
     ):
         run_silent(cfg, ask=False)
         return
@@ -1691,7 +1694,10 @@ def main():
     if "--silent" in sys.argv or (
         cfg.get("run_on_startup", False)
         and "--gui" not in sys.argv
-        and not sys.stdin.isatty()
+        and (
+            not hasattr(sys.stdin, "isatty")
+            or not sys.stdin.isatty()
+        )
     ):
         run_silent(cfg, ask=False)
         return


### PR DESCRIPTION
## Summary
- avoid AttributeError when `sys.stdin` is `None`
- run py_compile check

## Testing
- `python -m py_compile nishizumi_setups_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_6841fdc77da8832aa68ee5023485e9af